### PR TITLE
リガチャを無効化

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -205,9 +205,9 @@ body {
 
 h1, h2, h3,
 h4, h5, h6 {
-    -webkit-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -moz-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-    -o-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
+    -webkit-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
+    -moz-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
+    -o-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
     color: #2E2E2E;
     line-height: 1.15em;
     margin: 0 0 0.4em 0;
@@ -253,9 +253,9 @@ a:hover {
 }
 
 p, ul, ol, dl {
-    -webkit-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-    -moz-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-    -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
+    -webkit-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
+    -moz-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
+    -o-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
     margin: 0 0 1.75em 0;
     text-rendering: geometricPrecision;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,9 +27,9 @@ body {
 
 h1, h2, h3,
 h4, h5, h6 {
-  -webkit-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-  -moz-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
-  -o-font-feature-settings: 'dlig' 1, 'liga' 1, 'lnum' 1, 'kern' 1;
+  -webkit-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
+  -moz-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
+  -o-font-feature-settings: 'dlig' 0, 'liga' 0, 'lnum' 1, 'kern' 1;
   color: #59585B;
   margin: 0;
   text-rendering: geometricPrecision;
@@ -44,9 +44,9 @@ a:hover {
 }
 
 p, ul, ol, dl {
-  -webkit-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-  -moz-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
-  -o-font-feature-settings: 'liga' 1, 'onum' 1, 'kern' 1;
+  -webkit-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
+  -moz-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
+  -o-font-feature-settings: 'liga' 0, 'onum' 1, 'kern' 1;
   margin: 0 0 1.6rem 0;
   text-rendering: geometricPrecision;
   word-break: break-all;


### PR DESCRIPTION
「お願いします。」の「ます」が 〼 になっていたのを修正するために、
リガチャを全体的に無効化しました。

修正前:

![image](https://user-images.githubusercontent.com/162862/31439490-456e5a24-aec7-11e7-9b15-782ccea98724.png)

修正後:

![image](https://user-images.githubusercontent.com/162862/31439530-6a81eab0-aec7-11e7-9c2e-9336b2a9e9e5.png)

