### PR TITLE
タイムテーブルのスタイルを調整&スマホレイアウト作成

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -360,8 +360,7 @@ button {
 }
 .default-section__table-wrap {
   margin: 0 auto;
-  padding: 0 20px;
-  max-width: 900px;
+  max-width: 970px;
 }
 .default-section__table {
   margin: 0 0 40px;
@@ -370,11 +369,11 @@ button {
 }
 .default-section__table__row {
   padding: 10px 0;
-  background: #F6F6F6;
+  background: #FFF;
   display: table-row;
 }
 .default-section__table__row:nth-of-type(even) {
-  background: #FFF;
+  border-bottom: 1px solid #f6f6f6;
 }
 .default-section__table__header {
   font-weight: bold;
@@ -382,7 +381,7 @@ button {
   background: #F85032;
 }
 .default-section__table__cell {
-  padding: 5px 10px;
+  padding: 10px;
   display: table-cell;
 }
 .default-section__table__cell--time {
@@ -396,7 +395,8 @@ button {
 }
 .default-section__table__title {
   font-weight: bold;
-  font-size: 2.4rem;
+  font-size: 2rem;
+  line-height: 1.6;
 }
 .default-section__table__subtitle {
   font-weight: bold;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -402,6 +402,8 @@ button {
 .default-section__table__cell {
   padding: 10px;
   display: table-cell;
+  font-size: 1.3rem;
+  line-height: 1.7;
 }
 .default-section__table__cell--time {
   width: 10%;
@@ -422,7 +424,7 @@ button {
   font-size: 1.6rem;
 }
 .default-section__table__body {
-  
+
 }
 
 /* post */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -391,27 +391,35 @@ button {
   background: #FFF;
   display: table-row;
 }
-.default-section__table__row:nth-of-type(even) {
-  border-bottom: 1px solid #f6f6f6;
+.default-section__table__label {
+  border-bottom: 1px solid #F85032;
+  font-size: 1.2rem;
+  padding: 2px 4px;
+  color: #F85032;
+  display: block;
+  margin: 0 0 8px;
 }
 .default-section__table__header {
   font-weight: bold;
   color: #FFF;
   background: #F85032;
+  display: none;
 }
 .default-section__table__cell {
   padding: 10px;
-  display: table-cell;
-  font-size: 1.3rem;
-  line-height: 1.7;
+  display: block;
 }
 .default-section__table__cell--time {
+  font-weight: bold;
+  background: #FAFAFA;
+}
+.default-section__table__column--time {
   width: 10%;
 }
-.default-section__table__cell--track1 {
+.default-section__table__column--track1 {
   width: 40%;
 }
-.default-section__table__cell--track2 {
+.default-section__table__column--track2 {
   width: 40%;
 }
 .default-section__table__title {
@@ -422,9 +430,6 @@ button {
 .default-section__table__subtitle {
   font-weight: bold;
   font-size: 1.6rem;
-}
-.default-section__table__body {
-
 }
 
 /* post */
@@ -502,6 +507,15 @@ button {
   }
   .default-section__card--speakers {
     width: 50%;
+  }
+  .default-section__table__header {
+    display: table-row;
+  }
+  .default-section__table__label {
+    display: none;
+  }
+  .default-section__table__cell {
+    display: table-cell;
   }
   .hidden-mb {
     display: inherit;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -361,7 +361,7 @@ button {
 .default-section__table-wrap {
   margin: 0 auto;
   padding: 0 20px;
-  max-width: 800px;
+  max-width: 900px;
 }
 .default-section__table {
   margin: 0 0 40px;
@@ -385,16 +385,27 @@ button {
   padding: 5px 10px;
   display: table-cell;
 }
+.default-section__table__cell--time {
+  width: 10%;
+}
+.default-section__table__cell--track1 {
+  width: 40%;
+}
+.default-section__table__cell--track2 {
+  width: 40%;
+}
+.default-section__table__title {
+  font-weight: bold;
+  font-size: 2.4rem;
+}
+.default-section__table__subtitle {
+  font-weight: bold;
+  font-size: 1.6rem;
+}
+.default-section__table__body {
+  
+}
 
-.cell0 {
-  width: 4%
-}
-.cell1 {
-  width: 47%
-}
-.cell2 {
-  width: 49%
-}
 /* post */
 
 .post {

--- a/speakers.html
+++ b/speakers.html
@@ -48,7 +48,7 @@ Ruby関連の書籍では『Rubyのしくみ』（オーム社）や『なるほ
 http://mizzy.org/ https://github.com/mizzy
     </p>
   </div>
-  <div id="matsuotory" class="default-section__card default-section__card--speakers">
+  <div id="matsumotory" class="default-section__card default-section__card--speakers">
     <h2 class="default-section__title">松本亮介 <a href="https://github.com/matsumotory" target="_blank"><i class="fa fa-github" aria-hidden="true"></i></a></h2>
     <h3 class="default-section__body">「200万ドメインのHTTPS化を見据えたmrubyによる大規模証明書管理アーキテクチャ - サーバ台数を100分の1にする技術」</h2>
     <p class="default-section__caption">

--- a/timetable.html
+++ b/timetable.html
@@ -46,7 +46,10 @@ layout: post
           このメソッドはこんなときのためにあったんだ。このメソッドはこんな風にも動くんだ。そうそう、こう書きたかったんだ。プログラミングの中でそんな発見をするたびに、ぼくはRubyと出会えた感覚を覚えて嬉しくなります。<br>
           本セッションでは、プログラミングの中でRubyと出会うそうした瞬間をみなさんと共有できればと考えています。
         </p>
-        <p>Speaker <a href="./speakers.html#snoozer05">島田浩二</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#snoozer05">島田浩二</a>
+        </div>
       </div>
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">Rubyで書くParser</h2>
@@ -54,7 +57,10 @@ layout: post
         <p>
           Rubyで構文解析パーサーを書いたことはありますか？ このセッションでは、気軽にスクラッチから書くパーサーがいかにバギーで、落とし穴が多く、しかし楽しいかをお話しします。併せて、treetop という既存のパーサー用のgem との比較についてもお話しします。
         </p>
-        <p>Speaker <a href="./speakers.html#yotii23">鳥井雪</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#yotii23">鳥井雪</a>
+        </div>
       </div>
     </div>
     <div class="default-section__table__row">
@@ -68,7 +74,10 @@ layout: post
           PHPからRubyに移行すると決めてから1年、メドピアがRubyと出会い、そこから取り組んできた施策などをご紹介！<br />
           開発スピードが上がり、施策実現の数が増え、サイトが活性化するという好循環が生まれてきた話をします。
         </p>
-        <p>Speaker 福村彰展（<a href="https://medpeer.co.jp/">メドピア株式会社</a> 執行役員 CTO）</p>
+        <div>
+          <strong>Speaker</strong><br>
+          福村彰展（<a href="https://medpeer.co.jp/">メドピア株式会社</a> 執行役員 CTO）
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -85,7 +94,10 @@ layout: post
           ・コードの話<br>
           ・<a href="http://rubykaigi.org/2018">RubyKaigi 2018</a> に行きたくなる、そんな話<br>
         </p>
-        <p>Speaker <a href="./index.html#keynotes">松田明</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./index.html#keynotes">松田明</a>
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -108,11 +120,14 @@ layout: post
       </div>
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">めんたいトーク #2:</h2>
-        <h3 class="default-section__table__subttitle">マネーフォワードにおけるRubyエコシステム事例の紹介と、CTOより福岡の皆様へご挨拶</h3>
+        <h3 class="default-section__table__subtitle">マネーフォワードにおけるRubyエコシステム事例の紹介と、CTOより福岡の皆様へご挨拶</h3>
         <p>
           CTOの中出より挨拶をさせていただき、その後フルタイムRubyコミッターの卜部よりマネーフォワードで取り組みつつあるビルドパイプラインや、Rubyをどのように使うことで生産性を上げているか等、日々の生活の様子をご紹介します。
         </p>
-        <p>Speaker 中出匠哉（<a href="https://corp.moneyforward.com/">株式会社マネーフォワード</a> CTO） 卜部昌平（同 フルタイムRubyコミッター）</p>
+        <div>
+          <strong>Speaker</strong><br>
+          中出匠哉（<a href="https://corp.moneyforward.com/">株式会社マネーフォワード</a> CTO） 卜部昌平（同 フルタイムRubyコミッター）
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -128,7 +143,10 @@ layout: post
         <p>
           現在開発中のlibspecinfraというプロジェクトをベースに、Rustで書いたライブラリをRubyやmrubyから呼び出すための方法について解説します。インターネット上ではサンプルレベルのコードの書き方はすぐ見つかるものの、実際のプロダクト開発で参考になるコード例がなかなか見つからず苦労しました。同様のことをしたい人が苦労せずに済むよう、得られた知見についてお話します。
         </p>
-        <p>Speaker <a href="./speakers.html#mizzy">宮下剛輔</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#mizzy">宮下剛輔</a>
+        </div>
       </div>
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">Railsチュートリアルを支える継続的組版技術</h2>
@@ -137,7 +155,10 @@ layout: post
           電子書籍: <a href="https://gumroad.com/l/railstutorialjp_ebook">https://gumroad.com/l/railstutorialjp_ebook</a><br>
           Railsチュートリアルを継続的に更新し続けるため、ビジネスとして様々な取り組みを行なっておりますが、本発表ではその中でもRubyを使った継続的組版技術についてお話します。
         </p>
-        <p>Speaker <a href="./speakers.html#yasulab">安川要平</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#yasulab">安川要平</a>
+        </div>
       </div>
     </div>
 
@@ -151,7 +172,10 @@ layout: post
         <p>
           IoT開発者向けテスト支援サービスである mockmock の舞台裏をお見せいたします。<br />「mockmock って、どんなことができるの？」というところから、サービスのアーキテクチャや技術的課題まで、自社サービスの開発に携わるエンジニアが日常的に感じているおもしろさや、向き合っている困難をみなさんと共有できればと思います。
         </p>
-        <p>Speaker 毛利啓太（<a href="https://fusic.co.jp/">株式会社Fusic</a> 技術開発部門 mockmock開発チーム） 高瀬昭弘（同 mockmock開発チーム）</p>
+        <div>
+          <strong>Speaker</strong><br>
+          毛利啓太（<a href="https://fusic.co.jp/">株式会社Fusic</a> 技術開発部門 mockmock開発チーム） 高瀬昭弘（同 mockmock開発チーム）
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -169,7 +193,7 @@ layout: post
           「とんこつスポンサー」に名乗り出ていただいた5社様に、5分一本勝負のLTをお願いします！<br>
           発表予定のスポンサーは以下の皆様です。
         </p>
-        <p>Speakers 
+        <p>
           <ol>
             <li>
               <strong>「サービス展開を支えるRubyの活用と組織的スケーリングの勝利の鍵」</strong>
@@ -204,7 +228,10 @@ layout: post
         <p>
           コンパイラ最適化の限界を越えられる（かもしれない）コンパイル時計算の世界についてです。コンパイラの専門家でもないので、たまにC++などで使っていた側としてゆるふわに語ります。
         </p>
-        <p>Speaker <a href="./speakers.html#take-cheeze">take-cheeze</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#take-cheeze">take-cheeze</a>
+        </div>
       </div>
     </div>
 
@@ -229,7 +256,10 @@ layout: post
         <p>
           常時HTTPS化が進む中で，高集積マルチテナント方式のWebサーバで管理している大量のホストもHTTPS化を進めていく必要がある．そこで，事前にサーバプロセスに証明書を読み込まず，TLSハンドシェイク時に動的に証明書を読み込み，メモリ使用量を低減させる手法を提案する．実装には，ngx_mrubyを採用し，GMOペパボ株式会社のホスティングサービスにおいて本手法を導入して，実運用上の評価を行った
         </p>
-        <p>Speaker <a href="./speakers.html#matsumotory">松本亮介</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#matsumotory">松本亮介</a>
+        </div>
       </div>
       <div class="default-section__table__cell default-section__table__cell--talk">
         <h2 class="default-section__table__title">なぜRubyだったのか？Rubyで成長したOSS</h2>
@@ -238,7 +268,10 @@ layout: post
           その中で、なぜRubyを採用したのか、そのツールがRubyのコミュニティでどのように成長したのか、様々な問題をRubyの世界でどのように解決したのか、どのようなPull Requestがあったのかを話します。
           本発表で1つのRubyのOSSの成長を紹介できると思います。
         </p>
-        <p>Speaker <a href="./speakers.html#k1low">小山健一郎</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./speakers.html#k1low">小山健一郎</a>
+        </div>
       </div>
     </div>
 
@@ -252,7 +285,10 @@ layout: post
         <p>
           Cookpad の取り組みと Ruby でどのような事をやっているかを説明します。
         </p>
-        <p>Speaker 庄司嘉織（<a href="https://cookpad.com/">クックパッド株式会社</a> 技術部部長/エンジニア統括マネージャ）
+        <div>
+          <strong>Speaker</strong><br>
+          庄司嘉織（<a href="https://cookpad.com/">クックパッド株式会社</a> 技術部部長/エンジニア統括マネージャ）
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -268,7 +304,10 @@ layout: post
         <p>
           プログラムの挙動を追跡するのは、性能解析や挙動解析などを行うために重要である。Ruby (MRI) にはそのための仕組みとして、VM の <code>trace</code> 命令と、それを用いた TracePoint を用意している。しかし、現在の仕組みでは、非トレース時の実行時負荷が若干（最大で1割ほど）生じ、また任意の点に追跡点を仕込むことができず、柔軟な追跡が困難という問題がある。そこで、本発表ではこれらの問題点を解決する新しい追跡機構について紹介する。新しい機構では、 <code>trace</code> 命令を用いるのではなく、各命令に付加的な情報を持たせ、命令書き換えを利用して実現する。発表では、本機構の設計と実装、そして実装と評価について紹介する。さらに、本機構によって可能になる言語機能のアイディアについても議論する。
         </p>
-        <p>Speaker <a href="./index.html#keynotes">笹田耕一</a></p>
+        <div>
+          <strong>Speaker</strong><br>
+          <a href="./index.html#keynotes">笹田耕一</a>
+        </div>
       </div>
       <div class="default-section__table__cell">
         準備
@@ -284,8 +323,10 @@ layout: post
         <p>
           ??????
         </p>
-        <h4>Speaker</h4>
-        近藤うちお（実行委員長）
+        <div>
+          <strong>Speaker</strong><br>
+          近藤うちお（実行委員長）
+        </div>
       </div>
       <div class="default-section__table__cell">
       </div>

--- a/timetable.html
+++ b/timetable.html
@@ -2,9 +2,6 @@
 title: 'Time Table'
 layout: post
 ---
-<div class="default-section__card-wrap">
-  <p>※ 時間帯等について、調整の可能性があります。ご了承ください。</p>
-</div>
 <div class="default-section__table-wrap">
   <div class="default-section__table">
     <div class="default-section__table__row default-section__table__header">
@@ -25,24 +22,21 @@ layout: post
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">開場</h2>
       </div>
-      <div class="default-section__table__cell">
-        (準備)
-      </div>
     </div>
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        10:10 ~
+        10:10
       </div>
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">Opening by udzura</h2>
       </div>
       <div class="default-section__table__cell">
-        (準備)
+        準備
       </div>
     </div>
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        10:20 ~
+        10:20
       </div>
       <div class="default-section__table__cell">
         <h2 class="default-section__table__title">A Ruby Programming Episode</h2>
@@ -51,64 +45,51 @@ layout: post
           このメソッドはこんなときのためにあったんだ。このメソッドはこんな風にも動くんだ。そうそう、こう書きたかったんだ。プログラミングの中でそんな発見をするたびに、ぼくはRubyと出会えた感覚を覚えて嬉しくなります。<br>
           本セッションでは、プログラミングの中でRubyと出会うそうした瞬間をみなさんと共有できればと考えています。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#snoozer05">島田浩二</a>
+        <p>Speaker <a href="./speakers.html#snoozer05">島田浩二</a></p>
       </div>
       <div class="default-section__table__cell">
-        <h2>Rubyで書くParser</h2>
-        <h3>(自力かライブラリか、それが問題だ）</h3>
+        <h2 class="default-section__table__title">Rubyで書くParser</h2>
+        <h3 class="default-section__table__subtitle">(自力かライブラリか、それが問題だ）</h3>
         <p>
           Rubyで構文解析パーサーを書いたことはありますか？ このセッションでは、気軽にスクラッチから書くパーサーがいかにバギーで、落とし穴が多く、しかし楽しいかをお話しします。併せて、treetop という既存のパーサー用のgem との比較についてもお話しします。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#yotii23">鳥井雪</a>
+        <p>Speaker <a href="./speakers.html#yotii23">鳥井雪</a></p>
       </div>
     </div>
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        11:00 ~
+        11:00
       </div>
       <div class="default-section__table__cell">
-        <h3>企業LTその1 (15分)</h3>
+        <h2 class="default-section__table__title">企業LTその1 (15分)</h2>
       </div>
       <div class="default-section__table__cell">
-      </div>
-    </div>
-    <div class="default-section__table__row">
-      <div class="default-section__table__cell">
-        11:15 ~
-      </div>
-      <div class="default-section__table__cell">
-        <h2>Keynote:<br />Finding Ruby Again</h2>
-        <p>TBD...</p>
-        <ul>
-          <li>コードの話</li>
-          <li><a href="http://rubykaigi.org/2018">RubyKaigi 2018</a> に行きたくなる、そんな話</li>
-        </ul>
-        <h4>Speaker</h4>
-        <a href="./index.html#keynotes">松田明</a>
-      </div>
-      <div class="default-section__table__cell">
+        準備
       </div>
     </div>
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        12:10 ~
-        13:10
+        11:15
       </div>
       <div class="default-section__table__cell">
-        <h3>ランチタイム</h3>
+        <h2 class="default-section__table__title">Keynote: Finding Ruby Again</h2>
+        <p>
+          TBD...<br>
+          ・コードの話<br>
+          ・<a href="http://rubykaigi.org/2018">RubyKaigi 2018</a> に行きたくなる、そんな話<br>
+        </p>
+        <p>Speaker <a href="./index.html#keynotes">松田明</a></p>
       </div>
       <div class="default-section__table__cell">
+        準備
       </div>
     </div>
-
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        13:15 ~
+        12:10
       </div>
       <div class="default-section__table__cell">
-        <h3>企業LTその2 (15分)</h3>
+        <h2 class="default-section__table__title">ランチタイム</h2>
       </div>
       <div class="default-section__table__cell">
       </div>
@@ -116,139 +97,140 @@ layout: post
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        13:30 ~
+        13:15
       </div>
       <div class="default-section__table__cell">
-        <h2>Rustで書いたライブラリをRuby/mrubyから呼び出す実践的な方法</h2>
+        <h2 class="default-section__table__title">企業LTその2 (15分)</h2>
+      </div>
+      <div class="default-section__table__cell">
+        準備
+      </div>
+    </div>
+
+    <div class="default-section__table__row">
+      <div class="default-section__table__cell">
+        13:30
+      </div>
+      <div class="default-section__table__cell">
+        <h2 class="default-section__table__title">Rustで書いたライブラリをRuby/mrubyから呼び出す実践的な方法</h2>
         <p>
           現在開発中のlibspecinfraというプロジェクトをベースに、Rustで書いたライブラリをRubyやmrubyから呼び出すための方法について解説します。インターネット上ではサンプルレベルのコードの書き方はすぐ見つかるものの、実際のプロダクト開発で参考になるコード例がなかなか見つからず苦労しました。同様のことをしたい人が苦労せずに済むよう、得られた知見についてお話します。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#mizzy">宮下剛輔</a>
+        <p>Speaker <a href="./speakers.html#mizzy">宮下剛輔</a></p>
       </div>
       <div class="default-section__table__cell">
-        <h2 style="padding-bottom: 1.8em;">Railsチュートリアルを支える継続的組版技術</h2>
+        <h2 class="default-section__table__title">Railsチュートリアルを支える継続的組版技術</h2>
         <p>
           Railsチュートリアルでは、Web版で全てのコンテンツを無償で公開しつつ、電子書籍や解説動画などを有償で提供しております。<br>
           電子書籍: <a href="https://gumroad.com/l/railstutorialjp_ebook">https://gumroad.com/l/railstutorialjp_ebook</a><br>
           Railsチュートリアルを継続的に更新し続けるため、ビジネスとして様々な取り組みを行なっておりますが、本発表ではその中でもRubyを使った継続的組版技術についてお話します。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#yasulab">安川要平</a>
+        <p>Speaker <a href="./speakers.html#yasulab">安川要平</a></p>
       </div>
     </div>
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        14:20 ~
+        14:20
       </div>
       <div class="default-section__table__cell">
-        <h3>企業LTその3 (15分)</h3>
+        <h2 class="default-section__table__title">企業LTその3 (15分)</h2>
       </div>
       <div class="default-section__table__cell">
+        準備
       </div>
     </div>
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        14:35 ~
+        14:35
       </div>
       <div class="default-section__table__cell">
-        <h2>スポンサーLT大会</h2>
-        <h3>「とんこつスタジアム」（仮題）</h3>
+        <h2 class="default-section__table__title">スポンサーLT大会</h2>
+        <h3 class="default-section__table__subtitle">「とんこつスタジアム」（仮題）</h3>
         <p>
           「とんこつスポンサー」に名乗り出ていただいた5社様に、5分一本勝負のLTをお願いします！<br>
           発表予定のスポンサーは以下の皆様となります。
         </p>
-        <h4>Speakers</h4>
-        <ul>
-          <li>ピクシブ</li>
-          <li>GMOペパボ</li>
-          <li>メンバーズ</li>
-          <li>フロイデ</li>
-          <li>虎の穴</li>
-        </ul>
+        <p>Speaker ピクシブ,GMOペパボ,メンバーズ,フロイデ,虎の穴</p>
       </div>
       <div class="default-section__table__cell">
-        <h2 style="padding-bottom: 1.35em;">コンパイル時計算への招待</h2>
+        <h2 class="default-section__table__title">コンパイル時計算への招待</h2>
         <p>
           コンパイラ最適化の限界を越えられる（かもしれない）コンパイル時計算の世界についてです。コンパイラの専門家でもないので、たまにC++などで使っていた側としてゆるふわに語ります。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#take-cheeze">take-cheeze</a>
+        <p>Speaker <a href="./speakers.html#take-cheeze">take-cheeze</a></p>
       </div>
     </div>
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        15:05 ~
+        15:05
+      </div>
+      <div class="default-section__table__cell">
+        <h2 class="default-section__table__title">休憩</h2>
+      </div>
+      <div class="default-section__table__cell">
+      </div>
+    </div>
+
+    <div class="default-section__table__row">
+      <div class="default-section__table__cell">
         15:30
       </div>
-      <div class="default-section__table__cell">
-        <h3>休憩</h3>
-      </div>
-      <div class="default-section__table__cell">
-      </div>
-    </div>
-
-    <div class="default-section__table__row">
-      <div class="default-section__table__cell">
-        15:30 ~
-      </div>
-      <div class="default-section__table__cell">
-        <h2>200万ドメインのHTTPS化を見据えたmrubyによる大規模証明書管理アーキテクチャ</h2>
-        <h3>サーバ台数を100分の1にする技術</h3>
+      <div class="default-section__table__cell default-section__table__cell--talk">
+        <h2 class="default-section__table__title">200万ドメインのHTTPS化を見据えたmrubyによる大規模証明書管理アーキテクチャ</h2>
+        <h3 class="default-section__table__subtitle">サーバ台数を100分の1にする技術</h3>
         <p>
           常時HTTPS化が進む中で，高集積マルチテナント方式のWebサーバで管理している大量のホストもHTTPS化を進めていく必要がある．そこで，事前にサーバプロセスに証明書を読み込まず，TLSハンドシェイク時に動的に証明書を読み込み，メモリ使用量を低減させる手法を提案する．実装には，ngx_mrubyを採用し，GMOペパボ株式会社のホスティングサービスにおいて本手法を導入して，実運用上の評価を行った
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#matsumotory">松本亮介</a>
+        <p>Speaker <a href="./speakers.html#matsumotory">松本亮介</a></p>
       </div>
-      <div class="default-section__table__cell">
-        <h2 style="padding-bottom: 3.2em;">なぜRubyだったのか？Rubyで成長したOSS</h2>
+      <div class="default-section__table__cell default-section__table__cell--talk">
+        <h2 class="default-section__table__title">なぜRubyだったのか？Rubyで成長したOSS</h2>
         <p>
           発表者は、PHPのエンジニアでありながらRuby製のツールとしてawspecというツールを作成しメンテナンスしています。<br>
-その中で、なぜRubyを採用したのか、そのツールがRubyのコミュニティでどのように成長したのか、様々な問題をRubyの世界でどのように解決したのか、どのようなPull Requestがあったのかを話します。
-本発表で1つのRubyのOSSの成長を紹介できると思います。
+          その中で、なぜRubyを採用したのか、そのツールがRubyのコミュニティでどのように成長したのか、様々な問題をRubyの世界でどのように解決したのか、どのようなPull Requestがあったのかを話します。
+          本発表で1つのRubyのOSSの成長を紹介できると思います。
         </p>
-        <h4>Speaker</h4>
-        <a href="./speakers.html#k1low">小山健一郎</a>
+        <p>Speaker <a href="./speakers.html#k1low">小山健一郎</a></p>
       </div>
     </div>
     
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        16:20 ~
+        16:20
+      </div>
+      <div class="default-section__table__cell default-section__table__cell--talk">
+        <h2 class="default-section__table__title">企業LTその4 (15分)</h2>
       </div>
       <div class="default-section__table__cell">
-        <h3>企業LTその4 (15分)</h3>
-      </div>
-      <div class="default-section__table__cell">
+        準備
       </div>
     </div>
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        16:35 ~
+        16:35
       </div>
-      <div class="default-section__table__cell">
-        <h2>Keynote: Rubyにおける<br />トレース機構の刷新</h2>
+      <div class="default-section__table__cell default-section__table__cell--talk">
+        <h2 class="default-section__table__title">Keynote: Rubyにおけるトレース機構の刷新</h2>
         <p>
           プログラムの挙動を追跡するのは、性能解析や挙動解析などを行うために重要である。Ruby (MRI) にはそのための仕組みとして、VM の trace 命令と、それを用いた TracePoint を用意している。しかし、現在の仕組みでは、非トレース時の実行時負荷が若干（最大で1割ほど）生じ、また任意の点に追跡点を仕込むことができず、柔軟な追跡が困難という問題がある。そこで、本発表ではこれらの問題点を解決する新しい追跡機構について紹介する。新しい機構では、`trace` 命令を用いるのではなく、各命令に付加的な情報を持たせ、命令書き換えを利用して実現する。発表では、本機構の設計と実装、そして実装と評価について紹介する。さらに、本機構によって可能になる言語機能のアイディアについても議論する。
         </p>
-        <h4>Speaker</h4>
-        <a href="./index.html#keynotes">笹田耕一</a>
+        <p>Speaker <a href="./index.html#keynotes">笹田耕一</a></p>
       </div>
       <div class="default-section__table__cell">
+        準備
       </div>
     </div>
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        17:30 ~
+        17:30
       </div>
-      <div class="default-section__table__cell">
-        <h3>Closing talk by udzura</h3>
+      <div class="default-section__table__cell default-section__table__cell--talk">
+        <h2 class="default-section__table__title">Closing talk by udzura</h2>
         <p>
           ??????
         </p>
@@ -259,17 +241,15 @@ layout: post
 
     <div class="default-section__table__row">
       <div class="default-section__table__cell">
-        18:00 ~
-        18:30
+        18:00
       </div>
       <div class="default-section__table__cell">
-        <h3>退場（18:30完全撤収）</h3>
+        <h2 class="default-section__table__title">退場（18:30 完全撤収）</h2>
+        <p>ご協力をお願いします。</p>
       </div>
       <div class="default-section__table__cell">
-        <h3>ご協力をお願いします。</h3>
       </div>
     </div>
-
   </div>
-
+  <p>※時間帯等について、調整の可能性があります。ご了承ください。</p>
 </div>

--- a/timetable.html
+++ b/timetable.html
@@ -5,18 +5,19 @@ layout: post
 <div class="default-section__table-wrap">
   <div class="default-section__table">
     <div class="default-section__table__row default-section__table__header">
-      <div class="default-section__table__cell default-section__table__cell--time">
+      <div class="default-section__table__cell default-section__table__column--time">
         時刻
       </div>
-      <div class="default-section__table__cell default-section__table__cell--track1">
+      <div class="default-section__table__cell default-section__table__column--track1">
         トラック1
       </div>
-      <div class="default-section__table__cell default-section__table__cell--track2">
+      <div class="default-section__table__cell default-section__table__column--track2">
         トラック2
       </div>
     </div>
+
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         09:45
       </div>
       <div class="default-section__table__cell">
@@ -24,22 +25,26 @@ layout: post
       </div>
     </div>
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         10:10
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">Opening Talk</h2>
         <p>簡単な注意事項などがあります</p>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
+
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         10:20
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">A Ruby Programming Episode</h2>
         <p>
           ぼくにとって、「Rubyと出会う」瞬間はプログラミングしているときに訪れます。<br>
@@ -52,6 +57,7 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         <h2 class="default-section__table__title">Rubyで書くParser</h2>
         <h3 class="default-section__table__subtitle">(自力かライブラリか、それが問題だ）</h3>
         <p>
@@ -63,11 +69,13 @@ layout: post
         </div>
       </div>
     </div>
+
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         11:00
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">めんたいトーク #1:</h2>
         <h3 class="default-section__table__subtitle">メドピアの全力Rails化取り組み晒します</h3>
         <p>
@@ -80,14 +88,17 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
+
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         11:15
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">Keynote: Finding Ruby Again</h2>
         <p>
           TBD...<br>
@@ -100,11 +111,13 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
+
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         12:10
       </div>
       <div class="default-section__table__cell">
@@ -115,10 +128,11 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         13:15
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">めんたいトーク #2:</h2>
         <h3 class="default-section__table__subtitle">マネーフォワードにおけるRubyエコシステム事例の紹介と、CTOより福岡の皆様へご挨拶</h3>
         <p>
@@ -130,15 +144,17 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         13:30
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">Rustで書いたライブラリをRuby/mrubyから呼び出す実践的な方法</h2>
         <p>
           現在開発中のlibspecinfraというプロジェクトをベースに、Rustで書いたライブラリをRubyやmrubyから呼び出すための方法について解説します。インターネット上ではサンプルレベルのコードの書き方はすぐ見つかるものの、実際のプロダクト開発で参考になるコード例がなかなか見つからず苦労しました。同様のことをしたい人が苦労せずに済むよう、得られた知見についてお話します。
@@ -149,6 +165,7 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         <h2 class="default-section__table__title">Railsチュートリアルを支える継続的組版技術</h2>
         <p>
           Railsチュートリアルでは、Web版で全てのコンテンツを無償で公開しつつ、電子書籍や解説動画などを有償で提供しております。<br>
@@ -163,10 +180,11 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         14:20
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">めんたいトーク #3:</h2>
         <h3 class="default-section__table__subtitle">mockmockを支える技術</h3>
         <p>
@@ -178,15 +196,17 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         14:35
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">スポンサーLT大会</h2>
         <h3 class="default-section__table__subtitle">「とんこつスタジアム」（仮題）</h3>
         <p>
@@ -224,6 +244,7 @@ layout: post
         </p>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         <h2 class="default-section__table__title">コンパイル時計算への招待</h2>
         <p>
           コンパイラ最適化の限界を越えられる（かもしれない）コンパイル時計算の世界についてです。コンパイラの専門家でもないので、たまにC++などで使っていた側としてゆるふわに語ります。
@@ -236,7 +257,7 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         15:05
       </div>
       <div class="default-section__table__cell">
@@ -247,10 +268,11 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         15:30
       </div>
-      <div class="default-section__table__cell default-section__table__cell--talk">
+      <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">200万ドメインのHTTPS化を見据えたmrubyによる大規模証明書管理アーキテクチャ</h2>
         <h3 class="default-section__table__subtitle">サーバ台数を100分の1にする技術</h3>
         <p>
@@ -261,7 +283,8 @@ layout: post
           <a href="./speakers.html#matsumotory">松本亮介</a>
         </div>
       </div>
-      <div class="default-section__table__cell default-section__table__cell--talk">
+      <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         <h2 class="default-section__table__title">なぜRubyだったのか？Rubyで成長したOSS</h2>
         <p>
           発表者は、PHPのエンジニアでありながらRuby製のツールとしてawspecというツールを作成しメンテナンスしています。<br>
@@ -276,10 +299,11 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         16:20
       </div>
-      <div class="default-section__table__cell default-section__table__cell--talk">
+      <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">飛び梅トーク:</h2>
         <h3 class="default-section__table__subtitle">Cookpad と Ruby</h3>
         <p>
@@ -291,15 +315,17 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         16:35
       </div>
-      <div class="default-section__table__cell default-section__table__cell--talk">
+      <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">Keynote: Rubyにおけるトレース機構の刷新</h2>
         <p>
           プログラムの挙動を追跡するのは、性能解析や挙動解析などを行うために重要である。Ruby (MRI) にはそのための仕組みとして、VM の <code>trace</code> 命令と、それを用いた TracePoint を用意している。しかし、現在の仕組みでは、非トレース時の実行時負荷が若干（最大で1割ほど）生じ、また任意の点に追跡点を仕込むことができず、柔軟な追跡が困難という問題がある。そこで、本発表ではこれらの問題点を解決する新しい追跡機構について紹介する。新しい機構では、 <code>trace</code> 命令を用いるのではなく、各命令に付加的な情報を持たせ、命令書き換えを利用して実現する。発表では、本機構の設計と実装、そして実装と評価について紹介する。さらに、本機構によって可能になる言語機能のアイディアについても議論する。
@@ -310,15 +336,17 @@ layout: post
         </div>
       </div>
       <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 2</div>
         準備
       </div>
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         17:30
       </div>
-      <div class="default-section__table__cell default-section__table__cell--talk">
+      <div class="default-section__table__cell">
+        <div class="default-section__table__label">トラック 1</div>
         <h2 class="default-section__table__title">Closing Talk</h2>
         <p>
           ??????
@@ -333,7 +361,7 @@ layout: post
     </div>
 
     <div class="default-section__table__row">
-      <div class="default-section__table__cell">
+      <div class="default-section__table__cell default-section__table__cell--time">
         18:00
       </div>
       <div class="default-section__table__cell">

--- a/timetable.html
+++ b/timetable.html
@@ -5,23 +5,16 @@ layout: post
 <div class="default-section__card-wrap">
   <p>※ 時間帯等について、調整の可能性があります。ご了承ください。</p>
 </div>
-
-<hr>
-
-<div class="default-section__card-wrap">
-  <p> </p>
-</div>
-
 <div class="default-section__table-wrap">
   <div class="default-section__table">
     <div class="default-section__table__row default-section__table__header">
-      <div class="default-section__table__cell cell0">
+      <div class="default-section__table__cell default-section__table__cell--time">
         時刻
       </div>
-      <div class="default-section__table__cell cell1">
+      <div class="default-section__table__cell default-section__table__cell--track1">
         トラック1
       </div>
-      <div class="default-section__table__cell cell2">
+      <div class="default-section__table__cell default-section__table__cell--track2">
         トラック2
       </div>
     </div>
@@ -30,7 +23,7 @@ layout: post
         09:45
       </div>
       <div class="default-section__table__cell">
-        <h3>開場</h3>
+        <h2 class="default-section__table__title">開場</h2>
       </div>
       <div class="default-section__table__cell">
         (準備)
@@ -41,7 +34,7 @@ layout: post
         10:10 ~
       </div>
       <div class="default-section__table__cell">
-        <h3>Opening by udzura</h3>
+        <h2 class="default-section__table__title">Opening by udzura</h2>
       </div>
       <div class="default-section__table__cell">
         (準備)
@@ -52,11 +45,11 @@ layout: post
         10:20 ~
       </div>
       <div class="default-section__table__cell">
-        <h2 style="padding-bottom: 1.45em;">A Ruby Programming Episode</h2>
+        <h2 class="default-section__table__title">A Ruby Programming Episode</h2>
         <p>
-          ぼくにとって、「Rubyと出会う」瞬間はプログラミングしているときに訪れます。<br />
-このメソッドはこんなときのためにあったんだ。このメソッドはこんな風にも動くんだ。そうそう、こう書きたかったんだ。プログラミングの中でそんな発見をするたびに、ぼくはRubyと出会えた感覚を覚えて嬉しくなります。<br />
-本セッションでは、プログラミングの中でRubyと出会うそうした瞬間をみなさんと共有できればと考えています。
+          ぼくにとって、「Rubyと出会う」瞬間はプログラミングしているときに訪れます。<br>
+          このメソッドはこんなときのためにあったんだ。このメソッドはこんな風にも動くんだ。そうそう、こう書きたかったんだ。プログラミングの中でそんな発見をするたびに、ぼくはRubyと出会えた感覚を覚えて嬉しくなります。<br>
+          本セッションでは、プログラミングの中でRubyと出会うそうした瞬間をみなさんと共有できればと考えています。
         </p>
         <h4>Speaker</h4>
         <a href="./speakers.html#snoozer05">島田浩二</a>


### PR DESCRIPTION
@udzura 

## 概要

やったこと
- 既存タイムテーブルのスタイルとマークアップ修正
- スマホ用レイアウト作成
- ブラウザチェック（IE、モバイル実機除く）

| pc | mobile |
|---|---|
| <img width="1003" alt="2017-11-19 17 32 41" src="https://user-images.githubusercontent.com/953660/32988857-378ef34e-cd50-11e7-978a-c9dc500690df.png"> | <img width="448" alt="2017-11-19 17 32 28" src="https://user-images.githubusercontent.com/953660/32988862-477defb2-cd50-11e7-95ff-2b138c54e172.png"> |

## 注意点

- マークアップいじってるので、リンク先やトラック、時間などが間違ってしてないか確認お願いします。